### PR TITLE
[FEAT] 프로모션 당첨 실패 로직 구현 및 프론트 처리

### DIFF
--- a/src/main/java/com/lotte/danuri/promotion/handler/PromotionHandler.java
+++ b/src/main/java/com/lotte/danuri/promotion/handler/PromotionHandler.java
@@ -39,6 +39,11 @@ public class PromotionHandler {
         String memberId = request.headers().header("memberId").get(0);
         //String promotionId = request.headers().header("promotionId").get(0);
 
+        if(redisService.validEnd()) {
+            String msg = "exited";
+            return ServerResponse.ok().contentType(MediaType.APPLICATION_JSON).bodyValue(msg);
+        }
+
         // -1 : 프로모션 종료, null : 대기열 존재 안함, 작업열 존재 -> 쿠폰 받은 거 성공
         Long rank = redisService.getOrderNumber(Promotion.PROMOTION.waitKey, memberId);
         if(rank == null) { // 대기열 존재 안할 때 -> 1. 작업열로 이동, 2. 대기열에 진입 조차 못함

--- a/src/main/java/com/lotte/danuri/promotion/scheduler/QueueScheduler.java
+++ b/src/main/java/com/lotte/danuri/promotion/scheduler/QueueScheduler.java
@@ -23,6 +23,14 @@ public class QueueScheduler {
             log.info("======= 프로모션이 종료되었습니다. =======");
             log.info("작업열 사이즈 = {}",redisService.getSizeOfWork(Promotion.PROMOTION));
 
+            Long size = redisService.getSizeOfWork(Promotion.PROMOTION);
+            if(size > 0) {
+                for(int i=0;i<size;i++) {
+                    redisService.move(Promotion.PROMOTION);
+                    redisService.publish(Promotion.PROMOTION);
+                }
+            }
+
             redisService.delete(Promotion.PROMOTION);
             redisService.setPromotionCount(Promotion.PROMOTION.limit);
 


### PR DESCRIPTION
[작업 내용]
* 프로모션 당첨 실패 로직 구현
  * 서버 API에서 실패 메시지 리턴
  * 프론트 연결 작업
    * interval 호출 함수 종료 및 메시지 처리
    * 메인으로 redirect 설정